### PR TITLE
bugfix/#18-cart-count-is-blank

### DIFF
--- a/src/features/MobileStore/pages/Cart/components/CartItem/index.tsx
+++ b/src/features/MobileStore/pages/Cart/components/CartItem/index.tsx
@@ -165,7 +165,7 @@ const styles = StyleSheet.create({
   },
   newQuantity: {
     fontSize: 16,
-    fontWeight: 'bold',
+    // fontWeight: 'bold',
     paddingVertical: 4,
     paddingHorizontal: 8,
     borderWidth: 1,

--- a/src/features/MobileStore/pages/ItemDetail/index.tsx
+++ b/src/features/MobileStore/pages/ItemDetail/index.tsx
@@ -88,7 +88,7 @@ const styles = StyleSheet.create({
   },
   name: {
     fontSize: 32,
-    fontWeight: 'bold',
+    // fontWeight: 'bold',
     color: Design.colors.reddishBrown,
     alignSelf: 'flex-start',
   },


### PR DESCRIPTION
This PR fixes the empty cart count on seelct devices by disabled the bold fontWeight for the specific components.

closes #18